### PR TITLE
`Site Not Found`エラーを修正

### DIFF
--- a/two-afc/firebase.json
+++ b/two-afc/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "site": "apps-for-children-b2c4a",
+    "site": "apps-for-children",
     "public": "apps-for-children",
     "ignore": [
       "firebase.json",


### PR DESCRIPTION
既存の`apps-for-children-b2c4a`が反応していないようなので、別なサイト`apps-for-children`を作成し切り替えました。

それに伴い、URLが変わります。

公開URL：
> https://apps-for-children.web.app/   
> https://apps-for-children.firebaseapp.com/

Firebaseの設定画面：
> https://console.firebase.google.com/u/0/project/apps-for-children-b2c4a/hosting/sites/apps-for-children
